### PR TITLE
Update find command to only look for files

### DIFF
--- a/controls/V-2265.rb
+++ b/controls/V-2265.rb
@@ -28,7 +28,7 @@ find / -name *.jpp
 If either file type is found, this is a finding."
   tag "fix": "Remove the unnecessary files from the web server."
 
-  describe command("find / -name *.java") do
+  describe command("find / -name *.java -type f") do
     its('stdout') { should cmp "" }
   end
 


### PR DESCRIPTION
If /etc/.java (which is a valid settings directory) is present, then the control will fail. To fix this, the find command should have the flag `-type f`.